### PR TITLE
Fix server build by removing non-existent @types/vite

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,6 @@
       "@vitejs/plugin-react": "^4.3.2",
       "@replit/vite-plugin-cartographer": "^0.2.5",
       "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
-      "@types/vite": "^5.0.6",
       "nanoid": "^5.0.6",
       "drizzle-orm": "^0.39.1",
       "drizzle-zod": "^0.7.0",


### PR DESCRIPTION
## Summary
- remove `@types/vite` from the server `package.json`

The server's `package.json` referenced `@types/vite`, which does not exist in the npm registry. Removing it resolves `npm ERR! 404 '@types/vite@^5.0.6'` during installation.

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6866689cf7e88327b2d9c42431d51531